### PR TITLE
Fix studio splitter layout issue

### DIFF
--- a/packages/studio/src/components/Splitter/SplitterContainer.tsx
+++ b/packages/studio/src/components/Splitter/SplitterContainer.tsx
@@ -12,6 +12,7 @@ const containerRow: React.CSSProperties = {
 	flexDirection: 'row',
 	flex: 1,
 	height: '100%',
+	width: '100%',
 };
 
 export const containerColumn: React.CSSProperties = {


### PR DESCRIPTION
## Issue

In Remotion Studio, when the title of a video/audio is too long and exceeds the screen width (`innerWidth`), the timeline container also extends accordingly, causing the timeline to not be fully displayed at the minimum zoom level.

Here is an example that triggers this issue:

```typescript
export const MyComposition = () => {
	const videoUrl = 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4';
	return (
		<AbsoluteFill>
			<Video src={`${videoUrl}?${'x'.repeat(600)}`} />
		</AbsoluteFill>
	);
};
```

Before:

![image](https://github.com/XeroAlpha/remotion/assets/22394706/aa5d267f-ac59-43e5-b0a8-0e713972ca28)

After:

![image](https://github.com/XeroAlpha/remotion/assets/22394706/8d426f49-c265-4b39-b04e-437a11f25526)

This pull request fixes the issue. It is currently unclear whether this fix might cause other bugs.